### PR TITLE
Исправлена проблема с некорректным импортом log

### DIFF
--- a/src/main/java/urfu/gui/LogWindow.java
+++ b/src/main/java/urfu/gui/LogWindow.java
@@ -1,8 +1,8 @@
 package urfu.gui;
 
-import log.LogChangeListener;
-import log.LogEntry;
-import log.LogWindowSource;
+import urfu.log.LogChangeListener;
+import urfu.log.LogEntry;
+import urfu.log.LogWindowSource;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/urfu/gui/MainApplicationFrame.java
+++ b/src/main/java/urfu/gui/MainApplicationFrame.java
@@ -1,6 +1,6 @@
 package urfu.gui;
 
-import log.Logger;
+import urfu.log.Logger;
 
 import javax.swing.*;
 import java.awt.*;


### PR DESCRIPTION
В виду того, что импорты папок поменялись, а также изменилась общая архитектура, основной пакет `log` находился вне области `root`, - в `urfu`. Из-за чего необходимо было лишь указать перед перемещенными пакетами новый домен